### PR TITLE
enable regular Python 3.10 and remove 3.4 and 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,11 @@ At root level you can control with:
 
     - `py` - determines the python to provision for running the environment, if not set will be derived from the key:
       - `py27` or starts with `py27-` - Python 2.7
-      - `py34` or starts with `py34-` - Python 3.4
-      - `py35` or starts with `py35-` - Python 3.5
       - `py36` or starts with `py36-` - Python 3.6
       - `py37` or starts with `py37-` - Python 3.7
       - `py38` or starts with `py38-` - Python 3.8
       - `py39` or starts with `py39-` - Python 3.9
-      - `py310` or starts with `py39-` - Python 3.10 latest pre-release (only available on linux -- it is installed from
-        [deadsnakes](https://github.com/deadsnakes))
+      - `py310` or starts with `py310-` - Python 3.10
       - `pypy` or starts with `pypy-` - PyPy 2
       - `pypy3` or starts with `pypy3-` - PyPy 3
       - `jython` - Jython is available from under Linux and MacOs.

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -68,13 +68,16 @@ jobs:
                 displayName: "tox: install inline"
 
           # acquire target test Python
-          - ? ${{ if or(eq(job.key, 'py39'), startsWith(job.key, 'py39-'), eq(job.key, 'py38'), startsWith(job.key,
-              'py38-'), eq(job.key, 'py37'), startsWith(job.key, 'py37-'), eq(job.key, 'py36'), startsWith(job.key,
-              'py36-'), eq(job.key, 'py35'), startsWith(job.key, 'py35-'), eq(job.key, 'py34'), startsWith(job.key,
-              'py34-'), eq(job.key, 'py27'), startsWith(job.key, 'py27-'), eq(job.key, 'pypy'), startsWith(job.key,
-              'pypy-'), eq(job.key, 'pypy3'), startsWith(job.key, 'pypy3-'), eq(job.value.py, '2.7'), eq(job.value.py,
-              '3.4'), eq(job.value.py, '3.5'), eq(job.value.py, '3.6'), eq(job.value.py, '3.7'), eq(job.value.py,
-              'pypy2'), eq(job.value.py, 'pypy3')) }}
+          - ? ${{ if or(eq(job.key, 'py310'), startsWith(job.key, 'py310-'),
+              eq(job.key, 'py39'), startsWith(job.key, 'py39-'),
+              eq(job.key, 'py38'), startsWith(job.key, 'py38-'),
+              eq(job.key, 'py37'), startsWith(job.key, 'py37-'),
+              eq(job.key, 'py36'), startsWith(job.key, 'py36-'),
+              eq(job.key, 'py27'), startsWith(job.key, 'py27-'),
+              eq(job.key, 'pypy'), startsWith(job.key, 'pypy-'),
+              eq(job.key, 'pypy3'), startsWith(job.key, 'pypy3-'),
+              eq(job.value.py, '2.7'), eq(job.value.py, '3.6'), eq(job.value.py, '3.7'),
+              eq(job.value.py, 'pypy2'), eq(job.value.py, 'pypy3')) }}
             : - task: UsePythonVersion@0
                 displayName: ${{ format('provision target test python {0}', job.key) }}
                 inputs:
@@ -83,10 +86,6 @@ jobs:
                   ${{ if not(job.value.py) }}:
                     ${{ if or(eq(job.key, 'py27'), startsWith(job.key, 'py27-')) }}:
                       versionSpec: "2.7"
-                    ${{ if or(eq(job.key, 'py34'), startsWith(job.key, 'py34-')) }}:
-                      versionSpec: "3.4"
-                    ${{ if or(eq(job.key, 'py35'), startsWith(job.key, 'py35-')) }}:
-                      versionSpec: "3.5"
                     ${{ if or(eq(job.key, 'py36'), startsWith(job.key, 'py36-')) }}:
                       versionSpec: "3.6"
                     ${{ if or(eq(job.key, 'py37'), startsWith(job.key, 'py37-')) }}:
@@ -95,6 +94,8 @@ jobs:
                       versionSpec: "3.8"
                     ${{ if or(eq(job.key, 'py39'), startsWith(job.key, 'py39-')) }}:
                       versionSpec: "3.9"
+                    ${{ if or(eq(job.key, 'py310'), startsWith(job.key, 'py310-')) }}:
+                      versionSpec: "3.10"
                     ${{ if or(eq(job.key, 'pypy'), startsWith(job.key, 'pypy-')) }}:
                       versionSpec: "pypy2"
                     ${{ if or(eq(job.key, 'pypy3'), startsWith(job.key, 'pypy3-')) }}:
@@ -105,12 +106,6 @@ jobs:
                 displayName: "provision target test python via homebrew python@3"
               - script: echo "##vso[task.setvariable variable=PATH]/usr/local/opt/python@3:$(PATH)"
                 displayName: add python@3 to PATH
-          - ${{ if or(eq(job.key, 'py310'), startsWith(job.key, 'py310-')) }}:
-              - script: |
-                  sudo add-apt-repository ppa:deadsnakes
-                  sudo apt-get update
-                  sudo apt-get install -y --no-install-recommends python3.10-dev python3.10-venv python3.10-distutils
-                displayName: "provision python 3.10"
           - ${{ if or(eq(job.key, 'jython'), startsWith(job.key, 'jython-')) }}:
               - script:
                   wget

--- a/run-tox-env.yml
+++ b/run-tox-env.yml
@@ -19,7 +19,9 @@ jobs:
                     image: "ubuntu-latest"
                     image_name: "linux"
                   ${{ if eq(image, 'windows') }}:
-                    image: "windows-latest"
+                    # stay on windows-2019 since windows-latest (2022) has
+                    # problems with building C-extensions
+                    image: "windows-2019"
                     image_name: "windows"
                   ${{ if eq(image, 'macOs') }}:
                     image: "macOS-latest"


### PR DESCRIPTION
This PR addresses #13.

It makes Python 3.10 available on Linux, MacOS, and Windows. In order to be able to build C-extensions on Microsoft hosted Windows agents I hade to fix the image version to "windows-2019". This is in principle unrelated to the Python 3.10 support. If someone sees a more elegant solution please let me know. Its seems to me that Github actions has a similar problem with Windows-2022 -> see [here](https://github.com/lpsinger/github-actions-windows-2022-python-c-extension)

I tested these changes using the tests run on my package [dkriegner/xrayutilities](https://github.com/dkriegner/xrayutilities/pull/131).  

After first commit the tests on Windows runners fail, but Python 3.10 already works fine on Linux and MacOS. Pipeline logs [here](https://dev.azure.com/dominikkriegner/xrayutilities/_build/results?buildId=279&view=results)

With the windows image pinned to the 2019 version all my tests [succeed](https://dev.azure.com/dominikkriegner/xrayutilities/_build/results?buildId=280&view=results). 